### PR TITLE
Change GitChanges so it compares against the remote

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,6 +73,9 @@ module.exports = function (grunt) {
 			if (options.changes) {
 				args.push('--changes');
 			}
+			if (options.gitRemote) {
+				args.push('--git-remote', options.gitRemote);
+			}
 			if (options.debug) {
 				args.push('--debug');
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ optimist.boolean('single-thread');
 optimist.boolean('changes');
 optimist.default('changes', false);
 
+optimist.string('git-remote');
+optimist.default('git-remote', 'origin');
+
 optimist.boolean('dry');
 optimist.default('dry', false);
 
@@ -91,6 +94,7 @@ new TestRunner({
 	tslintConfig: path.join(path.dirname(testerPkgPath), 'conf', 'tslint.json'),
 
 	changes: (testFull ? false : argv['changes']),
+	gitRemote: argv['git-remote'],
 	tests: argv['dry'] ? false : argv['tests'],
 	lint: argv['dry'] ? false : argv['lint'],
 	headers: argv['dry'] ? false : argv['headers'],

--- a/src/test/ITestOptions.ts
+++ b/src/test/ITestOptions.ts
@@ -6,6 +6,7 @@ export interface ITestOptions {
 	tslintConfig: string;
 
 	changes: boolean;
+	gitRemote: string;
 	tests: boolean;
 	lint: boolean;
 	headers: boolean;

--- a/src/test/TestRunner.ts
+++ b/src/test/TestRunner.ts
@@ -46,7 +46,7 @@ export default class TestRunner {
 		this.options = options;
 
 		this.index = new FileIndex(this.options);
-		this.changes = new GitChanges(this.options.dtPath);
+		this.changes = new GitChanges(this.options.dtPath, this.options.gitRemote);
 
 		let tscVersion = 'unknown';
 		try {

--- a/src/util/GitChanges.ts
+++ b/src/util/GitChanges.ts
@@ -8,20 +8,23 @@ import * as util from './util';
 export default class GitChanges {
 
 	private dtPath: string;
+	private remote: string;
 
-	constructor(dtPath: string) {
+	constructor(dtPath: string, remote: string) {
 		this.dtPath = dtPath;
+		this.remote = remote;
 	}
 
 	public readChanges(): Promise<string[]> {
 		let dir = path.join(this.dtPath, '.git');
+		const remote = this.remote;
 
 		return util.fileExists(dir).then((exists) => {
 			if (!exists) {
 				throw new Error('cannot locate git-dir: ' + dir);
 			}
 			return new Promise<string[]>((resolve: (result: string[]) => void, reject: (error: any) => void) => {
-				let args = ['--name-only HEAD~1'];
+				let args = ['--name-only ' + remote];
 				let opts = {};
 				let git = new Git({
 					'git-dir': dir


### PR DESCRIPTION
The previous version was comparing against HEAD~1 which would:
A. Miss any changes prior to that of the last commit that had not yet been pushed
B. Grab changes not necessarily made by the current user (for example
if the current user only had staged changes but no commits, HEAD~1 would grab
those changes as well as the changes from the last commit)