### PR TITLE
Exclude '.' and deleted folders from changed folders

### DIFF
--- a/src/util/GitChanges.ts
+++ b/src/util/GitChanges.ts
@@ -13,7 +13,7 @@ export default class GitChanges {
 		this.dtPath = dtPath;
 	}
 
-	public readChanges(): Promise<util.FullPath[]> {
+	private readChanges(): Promise<util.FullPath[]> {
 		let dir = path.join(this.dtPath, '.git');
 
 		return util.fileExists(dir).then((exists) => {
@@ -35,5 +35,11 @@ export default class GitChanges {
 				});
 			});
 		});
+	}
+
+	public readChangedFolders(): Promise<string[]> {
+		return this.readChanges().then(changes =>
+			util.filterAsync(util.unique(changes.map(path.dirname)), folder =>
+				Promise.resolve(folder !== '.' && util.fileExists(folder))));
 	}
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -75,3 +75,16 @@ export function fixPath(str: string): string {
 		return s.toLowerCase();
 	});
 }
+
+export function filterAsync<T>(arr: T[], shouldKeep: (t: T) => Promise<boolean>): Promise<T[]> {
+	return Promise.all(arr.map(shouldKeep)).then(shouldKeeps =>
+		arr.filter((_, idx) => shouldKeeps[idx]));
+}
+
+export function unique(arr: string[]): string[] {
+	const set: { [name: string]: undefined } = {};
+	for (const value of arr) {
+		set[value] = undefined;
+	}
+	return Object.keys(set);
+}


### PR DESCRIPTION
While we're here, I did notice a potential error on line 85: `changedFolders.map(s => this.index.findFilesByName(/\w\.d\.ts$/));`. This appears to ignore the actual folder and just get every `.d.ts` file (but only if the extensionless name ends in a word character).
I also avoided using `Set` in the definition of `unique` because we seem to be running on version 0.10.0, according to our package.json "engines". Otherwise the definition would just be `Array.from(new Set(arr));`.