### PR TITLE
Upgrade version (and upgrade definition-header while we're at it)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "definition-tester",
-  "version": "2.0.5-alpha",
+  "version": "2.0.6-alpha",
   "description": "DefinitelyTyped repository testing infrastructure",
   "keywords": [
     "typescript",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "bluebird": "^3.3.4",
-    "definition-header": "^0.3.1",
+    "definition-header": "^0.3.3",
     "findup-sync": "^0.3.0",
     "glob": "^7.0.3",
     "lazy.js": "^0.4.2",


### PR DESCRIPTION
Should wait on #32.
If this is merged I will `npm publish` a new version.