### PR TITLE
Fixed -h/--help

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ let dtPath = util.fixPath(path.resolve(argv['path']));
 let cpuCores = os.cpus().length;
 
 if (argv.help) {
-	optimist.help();
+	console.log(optimist.help());
 	process.exit(0);
 }
 


### PR DESCRIPTION
`optimist.help()` just returns the help as a string and doesn’t print it.